### PR TITLE
re-implement groups

### DIFF
--- a/public/src/js/models/widgets.js
+++ b/public/src/js/models/widgets.js
@@ -55,9 +55,7 @@ var register = _.once(() => {
         template: { text: 'widgets/search_controls.html' }
     });
     ko.components.register('collection-widget', {
-        viewModel: {
-            createViewModel: (params) => params.context.$data
-        },
+        viewModel: { jspm: 'widgets/collection' },
         template: { text: 'widgets/collection.html' }
     });
     ko.components.register('trail-widget', {

--- a/public/src/js/widgets/collection.html
+++ b/public/src/js/widgets/collection.html
@@ -1,15 +1,15 @@
-<div class="collection" data-bind="ownerClass: $data">
+<div class="collection">
     <div class="list-header">
 
-        <span class="title" data-bind="
-            text: configMeta.displayName() || collectionMeta.displayName() || '(no title)'"></span>
+        <span class="title" data-bind="text: title"></span>
 
-        <span class="count" data-bind="if: !isPending()">
+        <span class="count" data-bind="if: !collection.isPending()">
             (<span data-bind="
-                text: state.count() ? state.count() : 'empty',
-                css: {'non-zero':  state.count}"></span>)
+                text: group.items().length || 'empty',
+                css: {'non-zero':  group.items().length}"></span>)
         </span>
 
+        <!-- ko with: collection -->
         <span class="count" data-bind="if: isPending()">
             (<span class="non-zero">updating...</span>)
         </span>
@@ -25,45 +25,18 @@
                 visible: state.hasConcurrentEdits,
                 ">Show edits</a>
         </span>
+        <!-- /ko -->
     </div>
 
     <div class="article-group">
         <div data-bind="
-            css: {'pending': isPending()},
-            template: {name: 'template_groups', foreach: groups}"></div>
+            css: {'pending': collection.isPending()},
+            template: {name: 'template_groups', data: group}"></div>
     </div>
 </div>
 
-<!-- ko if: state.hasExtraActions() && isHistoryEnabled() -->
-    <hr>
-
-    <div class="buttons">
-        <button data-bind="toggleClick: state.isHistoryOpen">
-            <span>Previously</span>
-            <!-- ko if: state.isHistoryOpen -->
-                <i class="fa fa-chevron-down"></i>
-            <!-- /ko -->
-            <!-- ko ifnot: state.isHistoryOpen -->
-                <i class="fa fa-chevron-up"></i>
-            <!-- /ko -->
-        </button>
-    </div>
-
-    <div class="history" data-bind="
-        slideVisible: state.isHistoryOpen(),
-        makeDraggable: true
-    ">
-        <!-- ko foreach: history -->
-            <trail-widget params="context: $context"></trail-widget>
-        <!-- /ko -->
-    </div>
-<!-- /ko -->
-
 
 <script type="text/html" id="template_groups">
-    <!-- ko if: name -->
-        <div class="group-name" data-bind="text: name"></div>
-    <!-- /ko -->
     <div class="droppable" data-bind="
         makeDroppable: true,
         click: pasteItem,

--- a/public/src/js/widgets/collection.js
+++ b/public/src/js/widgets/collection.js
@@ -1,0 +1,20 @@
+import _ from 'underscore';
+import BaseWidget from 'widgets/base-widget';
+
+export default class Collection extends BaseWidget {
+    constructor(params, element) {
+        super(params, element);
+
+        this.collection = params.context.$data;
+
+        this.group = _.find(this.collection.groups, group => group.name === params.group);
+
+        if (params.group === 'included') {
+            this.title = 'Included in ' + this.collection.configMeta.displayName();
+        } else {
+            this.title = 'Linking to ' + this.collection.configMeta.displayName();
+        }
+
+        this.collection.registerElement(element);
+    }
+}

--- a/public/src/js/widgets/columns/story-package.html
+++ b/public/src/js/widgets/columns/story-package.html
@@ -1,8 +1,8 @@
-<div class="modes" data-bind="css: frontMode">
+<div class="modes live-mode">
     <a class="live-mode active">Story package</a>
 </div>
 
-<div class="styledFront" data-bind="css: frontMode">
+<div class="styledFront live-mode">
     <div class="col__inner front-selector">
         <select class="select--front" data-bind="options: $root.latestPackages,
             optionsText: 'name',
@@ -27,10 +27,12 @@
     <!-- /ko -->
 </div>
 
-<div class="col__inner scrollable styledFront collection-container" data-bind="
-    css: frontMode
-">
+<div class="col__inner scrollable styledFront collection-container live-mode">
     <!-- ko with: collection -->
-        <collection-widget params="context: $context" class="cardContainer"></collection-widget>
+        <collection-widget params="context: $context, group: 'included'" class="cardContainer"></collection-widget>
+    <!-- /ko -->
+
+    <!-- ko with: collection -->
+        <collection-widget params="context: $context, group: 'linked'" class="cardContainer"></collection-widget>
     <!-- /ko -->
 </div>

--- a/public/src/js/widgets/columns/story-package.js
+++ b/public/src/js/widgets/columns/story-package.js
@@ -27,13 +27,6 @@ export default class Front extends ColumnWidget {
         });
 
         this.setFront = id => this.front(id);
-        this.setModeLive = () => this.mode('live');
-        this.setModeDraft = () => this.mode('draft');
-
-        this.frontMode = ko.pureComputed(() => {
-            var classes = [this.mode() + '-mode'];
-            return classes.join(' ');
-        });
 
         this.isControlsVisible = ko.observable(false);
         this.controlsText = ko.pureComputed(() => '');
@@ -111,7 +104,8 @@ export default class Front extends ColumnWidget {
                 displayName: response.name,
                 lastUpdated: response.lastModify,
                 updatedBy: response.lastModifyByName,
-                updatedEmail: response.lastModifyBy
+                updatedEmail: response.lastModifyBy,
+                groups: ['linked', 'included']
             });
             this.collection(newCollection);
             var latestPackages = this.baseModel.latestPackages();

--- a/public/test/spec/alternate.drag.spec.js
+++ b/public/test/spec/alternate.drag.spec.js
@@ -26,7 +26,7 @@ describe('Alternate Drag', function () {
 
 
         function openFirstArticle () {
-            return testPage.regions.front().collection(1).group(1).trail(1).open();
+            return testPage.regions.story().linking().trail(1).open();
         }
         function saveArticle (trail) {
             return testPage.actions.edit(() => {
@@ -137,11 +137,11 @@ describe('Alternate Drag', function () {
         }
         function expectItemSwapped () {
             mockScope.clear();
-            const trail = testPage.regions.front().collection(1).group(1).trail(1);
+            const trail = testPage.regions.story().linking().trail(1);
             expect(trail.fieldText('headline')).toBe('Santa Claus is a real thing');
         }
         function deleteEntireArticle () {
-            const trail = testPage.regions.front().collection(1).group(1).trail(1);
+            const trail = testPage.regions.story().linking().trail(1);
             return testPage.actions.edit(() => trail.remove())
             .assertRequest(request => {
                 expect(request.url).toBe('/edits');
@@ -154,7 +154,7 @@ describe('Alternate Drag', function () {
                         item: 'internal-code/page/4'
                     }
                 });
-                expect(testPage.regions.front().collection(1).group(1).isEmpty()).toBe(true);
+                expect(testPage.regions.story().linking().isEmpty()).toBe(true);
             })
             .respondWith({
                 'story-1': { live: [] }

--- a/public/test/spec/collections.spec.js
+++ b/public/test/spec/collections.spec.js
@@ -25,7 +25,7 @@ describe('Collections', function () {
         function insertInEmptyGroup () {
             return testPage.actions.edit(() => {
                 return testPage.regions.latest().trail(1).dropTo(
-                    testPage.regions.front().collection(1).group(1)
+                    testPage.regions.story().linking()
                 );
             })
             .assertRequest(request => {
@@ -36,7 +36,7 @@ describe('Collections', function () {
                 expect(request.data.update.live).toEqual(true);
                 expect(request.data.update.id).toEqual('story-2');
                 expect(request.data.update.item).toEqual('internal-code/page/1');
-                expect(!!request.data.update.itemMeta).toEqual(false);
+                expect(request.data.update.itemMeta).toEqual({ group: '0' });
             })
             .respondWith({
                 'story-2': {
@@ -54,7 +54,7 @@ describe('Collections', function () {
         function insertAfterAnArticle () {
             return testPage.actions.edit(() => {
                 return testPage.regions.latest().trail(2).dropTo(
-                    testPage.regions.front().collection(1)
+                    testPage.regions.story().linking()
                 );
             })
             .assertRequest(request => {
@@ -65,7 +65,7 @@ describe('Collections', function () {
                 expect(request.data.update.live).toEqual(true);
                 expect(request.data.update.id).toEqual('story-2');
                 expect(request.data.update.item).toEqual('internal-code/page/2');
-                expect(!!request.data.update.itemMeta).toEqual(false);
+                expect(request.data.update.itemMeta).toEqual({ group: '0' });
                 expect(request.data.update.position).toEqual('internal-code/page/1');
             })
             .respondWith({
@@ -83,7 +83,7 @@ describe('Collections', function () {
         function insertOnTopOfTheList () {
             return testPage.actions.edit(() => {
                 return testPage.regions.latest().trail(3).dropTo(
-                    testPage.regions.front().collection(1).group(1).trail(1)
+                    testPage.regions.story().linking().trail(1)
                 );
             })
             .assertRequest(request => {
@@ -94,7 +94,7 @@ describe('Collections', function () {
                 expect(request.data.update.live).toEqual(true);
                 expect(request.data.update.id).toEqual('story-2');
                 expect(request.data.update.item).toEqual('internal-code/page/3');
-                expect(!!request.data.update.itemMeta).toEqual(false);
+                expect(request.data.update.itemMeta).toEqual({ group: '0' });
                 expect(request.data.update.position).toEqual('internal-code/page/1');
             })
             .respondWith({
@@ -113,7 +113,7 @@ describe('Collections', function () {
 
         function insertMetadataOnTopOfTheList () {
             return testPage.actions.edit(() => {
-                return testPage.regions.front().collection(1).group(1).trail(1).open()
+                return testPage.regions.story().linking().trail(1).open()
                 .then(trail => trail.toggleMetadata('showQuotedHeadline'))
                 .then(trail => trail.save());
             })
@@ -147,9 +147,9 @@ describe('Collections', function () {
 
         function moveFirstItemBelow () {
             return testPage.actions.edit(() => {
-                var firstCollection = testPage.regions.front().collection(1);
-                return firstCollection.group(1).trail(1).dropTo(
-                    firstCollection.group(1).trail(3)
+                var storyPackage = testPage.regions.story();
+                return storyPackage.linking().trail(1).dropTo(
+                    storyPackage.linking().trail(3)
                 );
             })
             .assertRequest(request => {
@@ -182,7 +182,7 @@ describe('Collections', function () {
 
         function removeItemFromGroup () {
             return testPage.actions.edit(() => {
-                return testPage.regions.front().collection(1).group(1).trail(2).remove();
+                return testPage.regions.story().linking().trail(2).remove();
             })
             .assertRequest(request => {
                 expect(request.url).toEqual('/edits');
@@ -208,7 +208,7 @@ describe('Collections', function () {
             return testPage.actions.edit(() => {
                 const regions = testPage.regions;
                 return regions.latest().trail(5).copy()
-                .then(() => regions.front().collection(1).group(1).trail(1).paste());
+                .then(() => regions.story().linking().trail(1).paste());
             })
             .assertRequest(request => {
                 expect(request.url).toBe('/edits');
@@ -219,7 +219,8 @@ describe('Collections', function () {
                     draft: false,
                     id: 'story-2',
                     item: 'internal-code/page/5',
-                    position: 'internal-code/page/1'
+                    position: 'internal-code/page/1',
+                    itemMeta: { group: '0' }
                 });
             })
             .respondWith({
@@ -247,11 +248,11 @@ describe('Collections', function () {
     });
 
     it('closes without saving', function (done) {
-        this.testPage.regions.front().collection(1).group(1).trail(1).open()
+        this.testPage.regions.story().linking().trail(1).open()
         .then(trail => trail.type('headline', 'different'))
         .then(trail => trail.close())
         .then(() => {
-            const trail = this.testPage.regions.front().collection(1).group(1).trail(1);
+            const trail = this.testPage.regions.story().linking().trail(1);
             expect(trail.fieldText('headline')).toBe('I won the elections');
             expect($('.editor', trail.dom).is(':visible')).toBe(false);
         })

--- a/public/test/spec/media.service.spec.js
+++ b/public/test/spec/media.service.spec.js
@@ -17,7 +17,7 @@ describe('Media Service', function () {
     it('drags an image from the grid', function (done) {
         const testPage = this.testPage;
 
-        this.testPage.regions.front().collection(1).group(1).trail(1).open()
+        this.testPage.regions.story().linking().trail(1).open()
         .then(expectArticleOpen)
         .then(dragFromTheGrid)
         .then(openCutoutImageEditor)

--- a/public/test/utils/regions.js
+++ b/public/test/utils/regions.js
@@ -1,6 +1,7 @@
 import alert from 'test/utils/regions/alert';
 import clipboard from 'test/utils/regions/clipboard';
 import front from 'test/utils/regions/front';
+import story from 'test/utils/regions/story';
 import latest from 'test/utils/regions/latest';
 import breakingNewsModal from 'test/utils/regions/breaking-news-modal';
 
@@ -8,6 +9,7 @@ export default function install () {
     return {
         latest,
         front,
+        story,
         clipboard,
         alert,
         breakingNewsModal

--- a/public/test/utils/regions/story.js
+++ b/public/test/utils/regions/story.js
@@ -1,0 +1,24 @@
+import group from 'test/utils/regions/group';
+
+class Story {
+    constructor(dom) {
+        this.dom = dom;
+    }
+
+    linking() {
+        return group(2, this.dom, this);
+    }
+
+    included() {
+        return group(1, this.dom, this);
+    }
+
+    pacakgeSelector() {
+        return this.dom.querySelector('.front-selector');
+    }
+}
+
+export default function (number = 1) {
+    var dom = document.querySelectorAll('.collection-container')[number - 1].parentNode;
+    return new Story(dom);
+}


### PR DESCRIPTION
Story packages have now two groups, one for the story displayed inside the package, another for the ones that are simply linking to that package.