### PR TITLE
Search from capi

### DIFF
--- a/app/services/Database.scala
+++ b/app/services/Database.scala
@@ -68,32 +68,7 @@ object Database {
       )
     })
   }
-
-  def latestPackages(maxAge: Int, isHidden: Boolean = false): Future[StoryPackageSearchResult] = {
-    val errorMessage = s"Exception in latestPackages fetching packages since $maxAge days ago"
-    WithExceptionHandling(errorMessage, {
-      val since = new DateTime().withZone(DateTimeZone.UTC).minusDays(maxAge)
-      val values = new ValueMap()
-        .withString(":since", since.toString)
-        .withBoolean(":is_hidden", isHidden)
-        .withBoolean(":deleted", true)
-
-      val scanRequest = new ScanSpec()
-        .withFilterExpression("lastModify > :since and isHidden = :is_hidden and not deleted = :deleted")
-        .withValueMap(values)
-        .withMaxResultSize(Configuration.storage.maxLatestResults)
-
-      val results = table.scan(scanRequest)
-      StoryPackagesMetrics.ScanCount.increment()
-
-      import model.SortByLastModify._
-      StoryPackageSearchResult(
-        latest = Some(maxAge),
-        results = DynamoToScala.convertToListOfStoryPackages(results).sorted
-      )
-    })
-  }
-
+  
   def getPackage(id: String): Future[StoryPackage] = {
     val errorMessage = s"Unable to find story package with id $id"
     WithExceptionHandling(errorMessage, {

--- a/conf/routes
+++ b/conf/routes
@@ -48,7 +48,7 @@ GET         /json/proxy/*absUrl                      controllers.FaciaContentApi
 
 POST        /story-packages/create                   controllers.StoryPackagesController.create()
 GET         /story-packages/search/*term             controllers.StoryPackagesController.search(term)
-GET         /story-packages/latest                   controllers.StoryPackagesController.latest()
+GET         /story-packages/latest                   controllers.StoryPackagesController.capiLatest()
 DELETE      /story-package/*id                       controllers.StoryPackagesController.deletePackage(id)
 
 # Vanity URL

--- a/public/src/js/widgets/fetch-latest-packages.js
+++ b/public/src/js/widgets/fetch-latest-packages.js
@@ -19,7 +19,15 @@ export default class extends Extension {
                 isHidden: this.baseModel.priority === 'training'
             }
         })
-        .then(response => this.baseModel.latestPackages(response.results))
+        .then(result => {
+            return this.baseModel.latestPackages(result.response.results.map(result => {
+                return {
+                    name: result.packageName,
+                    lastModify: result.lastModified,
+                    id: result.packageId
+                };
+            }));
+        })
         .catch(function () {
             mediator.emit('packages:alert', 'Failed to fetch latest packages');
         });


### PR DESCRIPTION
@piuccio Capi returns a 'package name' property, but the client relies on the name property on the packages. I'm not sure what's the correct behaviour. 

