### PR TITLE
limit the number of availability zone

### DIFF
--- a/cloudformation/story-packages.json
+++ b/cloudformation/story-packages.json
@@ -34,7 +34,7 @@
         "AvailabilityZones": {
             "Description": "The availability zone where instances are allowed to run",
             "Type": "List<AWS::EC2::AvailabilityZone::Name>",
-            "Default": "eu-west-1a,eu-west-1b,eu-west-1c"
+            "Default": "eu-west-1b,eu-west-1c"
         },
         "SwitchboardBucket": {
             "Description": "Bucket where switchboard writes switches status",


### PR DESCRIPTION
As there are only two PROD instance, allow only two zones, this makes me more confident when buying reserved instances