### PR TITLE
Bump awsVersion to 1.11.999 for security work

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ TwirlKeys.templateImports ++= Seq(
 )
 
 
-val awsVersion = "1.11.280"
+val awsVersion = "1.11.999"
 val capiModelsVersion = "14.1"
 val json4sVersion = "3.5.0"
 


### PR DESCRIPTION
Bumps the AWS SDK version to be compatible with IMDSv2. This will reduce our exposure to various vulnerabilities, more details can be found [here](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md).
 
Linked to [this PR on `editorial-tools-platform`](https://github.com/guardian/editorial-tools-platform/pull/529).

## How to test?
Deploy this to CODE alongside the updating the stack, this should be a NO-OP.