### PR TITLE
Moved Xenial AMI to Bionic as it is no longer being supported

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,7 +26,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: story-packages
       amiTags:
-        Recipe: editorial-tools-bionic-java
+        Recipe: editorial-tools-bionic-java8
         AmigoStage: PROD
       amiParameter: MachineImageID
     type: ami-cloudformation-parameter

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,7 +26,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: story-packages
       amiTags:
-        Recipe: editorial-tools-bionic-java8
+        Recipe: editorial-tools-bionic-java
         AmigoStage: PROD
       amiParameter: MachineImageID
     type: ami-cloudformation-parameter

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -26,7 +26,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: story-packages
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8
         AmigoStage: PROD
       amiParameter: MachineImageID
     type: ami-cloudformation-parameter


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

Travis CI does not seem to be happy, though this appears to be the case for every open PR.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to [CODE](https://packages.code.dev-gutools.co.uk/editorial) via RiffRaff (it's under `cms-fronts::story-packages`), and ensure it deploys and runs correctly.