### PR TITLE
Add 'publicReadAcl: true' to the `static-story-packages` deployment step

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,7 +2,9 @@ stacks:
 - cms-fronts
 deployments:
   static-story-packages:
+    type: aws-s3
     parameters:
+      publicReadAcl: true
       cacheControl:
       - pattern: .*\.js$
         value: public, max-age=315360000
@@ -14,13 +16,13 @@ deployments:
         map: text/plain
       prefixStack: false
       bucket: cms-fronts-static-assets
-    type: aws-s3
   story-packages:
+    type: autoscaling
     parameters:
       bucket: story-packages-dist
-    type: autoscaling
     dependencies: [packages-ami]
   packages-ami:
+    type: ami-cloudformation-parameter
     parameters:
       cloudFormationStackByTags: false
       prependStackToCloudFormationStackName: false
@@ -29,6 +31,6 @@ deployments:
         Recipe: editorial-tools-bionic-java8
         AmigoStage: PROD
       amiParameter: MachineImageID
-    type: ami-cloudformation-parameter
+
 regions:
 - eu-west-1


### PR DESCRIPTION
also move the `type` property beneath the name of each deployment step for easier readability

_This addresses the changes to riff-raff, see https://github.com/guardian/riff-raff/pull/665_