### PR TITLE
fix: Use Java 8 and separate dependency tree plugin for Snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,3 @@
-# This action runs snyk monitor on every push to main
 name: Snyk
 
 on:
@@ -14,5 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian
       SKIP_NODE: false
+      JAVA_VERSION: 8
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
 
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+


### PR DESCRIPTION
Snyk monitoring of the `main` branch was already enabled for this project, but it is failing to work for the sbt project, because it needs running with Java 8 (default is 11).  Older SBT versions (this project uses 0.13.11) also needs an explicit dependency tree plugin adding.

This has been tested with https://github.com/guardian/story-packages/actions/runs/2703736189