### PR TITLE
Remove old resolvers

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,7 @@ logLevel := Level.Warn
 resolvers ++= Seq(
   Classpaths.typesafeReleases,
   Resolver.sonatypeRepo("releases"),
-  Resolver.typesafeRepo("releases"),
-  "Spy" at "https://files.couchbase.com/maven2/"
+  Resolver.typesafeRepo("releases")
 )
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,6 @@ resolvers ++= Seq(
   Classpaths.typesafeReleases,
   Resolver.sonatypeRepo("releases"),
   Resolver.typesafeRepo("releases"),
-  Resolver.url("sbt-plugin-snapshots", new URL("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots/"))(Resolver.ivyStylePatterns),
-  "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases",
   "Spy" at "https://files.couchbase.com/maven2/"
 )
 


### PR DESCRIPTION
## What does this change?

Removes a couple of old resolvers. They were not using https, and 404 anyhow.

## How to test

A passing build should be enough to prove that we don't need them.