### PR TITLE
Update RiffRaff deploy to use ARM AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -28,7 +28,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: story-packages
       amiTags:
-        Recipe: editorial-tools-focal-java8
+        Recipe: editorial-tools-focal-java8-ARM
         AmigoStage: PROD
       amiParameter: MachineImageID
 


### PR DESCRIPTION
## What's changed?
Update RiffRaff deploy to use ARM-based AMI. This is in support of migrating our apps to EC2 instance types with ARM-based Graviton processors, which are cheaper to run.