### PR TITLE
Order packages by relevance, instead of newest

### DIFF
--- a/app/controllers/StoryPackagesController.scala
+++ b/app/controllers/StoryPackagesController.scala
@@ -73,7 +73,7 @@ class StoryPackagesController(config: ApplicationConfiguration, components: Cont
     else
       config.contentApi.packagesLiveHost
 
-    val url = s"$contentApiHost/packages?order-by=newest&q=$encodedTerm${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
+    val url = s"$contentApiHost/packages?order-by=relevance&q=$encodedTerm${config.contentApi.key.map(key => s"&api-key=$key").getOrElse("")}"
 
     Logger.info(s"Proxying search query to: $url")
     wsClient.url(url).get().flatMap { response =>


### PR DESCRIPTION
Searches currently skew towards recent packages, at the expense of relevancy. By changing the order-by parameter, we should hopefully see more relevant search results (currently search results can be so irrelevant, that users are creating duplicate packages when they give up on finding the package they are looking for).

Note that this is actually a CAPI search under the hood, and recency is still factored into the search via an exponential decay function: https://github.com/guardian/content-api/blob/main/concierge/src/main/scala/com.gu.contentapi.concierge/model/ConciergeQueries.scala#L179-L188

By altering the recency / relevancy mix we should see better search results and fewer duplicates created. We may need to experiment more to change this mix, or rollback if there are unintended consequences (search is notoriously hard to fine-tune).

## How to test

Run locally / deploy to CODE and test the results. They should be more relevant than before. Note that CODE uses CODE CAPI, so may not be easy to test.

I have tested the CAPI query itself and it works as expected.