### PR TITLE
Revert "Update to fapi-client v4.0.6"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "com.gu" %% "content-api-models-scala" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.7",
-    "com.gu" %% "fapi-client-play28" % "4.0.6",
+    "com.gu" %% "fapi-client-play28" % "4.0.4",
     "com.gu" % "kinesis-logback-appender" % "1.3.0",
     "com.gu" %% "pan-domain-auth-play_2-8" % "1.3.0",
     "com.gu" %% "story-packages-model" % "2.2.0",
@@ -90,7 +90,7 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "com.typesafe.play" %% "play-json" % "2.9.4",
     "com.typesafe.play" %% "play-iteratees" % "2.6.1",
     "org.julienrf" %% "play-json-derived-codecs" % "10.1.0",
-    "org.scalatest" %% "scalatest" % "3.2.15" % Test
+    "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)


### PR DESCRIPTION
Reverts guardian/story-packages#184 as causing issues in PROD. Added a deploy restriction. Can be fixed forward and this PR closed if preferred.