### PR TITLE
Add Prout to `guardian/story-packages`

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -1,0 +1,5 @@
+{
+    "checkpoints": {
+        "PROD": { "url": "https://packages.gutools.co.uk/_healthcheck", "overdue": "20M" }
+    }
+}

--- a/app/controllers/StatusController.scala
+++ b/app/controllers/StatusController.scala
@@ -1,11 +1,12 @@
 package controllers
 
+import app.BuildInfo
 import conf.ApplicationConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.ControllerComponents
 
 class StatusController(config: ApplicationConfiguration, components: ControllerComponents, wsClient: WSClient) extends StoryPackagesBaseController(config, components, wsClient) {
   def healthStatus = Action { request =>
-    Ok("Ok.")
+    Ok(s"Ok.\ngitCommitId:${BuildInfo.gitCommitId}")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,6 @@ resolvers ++= Seq(
 )
 
 buildInfoPackage := "app"
-buildInfoOptions += BuildInfoOption.BuildTime
 buildInfoKeys += "gitCommitId" -> env.getOrElse("GITHUB_SHA", "Unknown")
 
 lazy val jacksonVersion = "2.13.4"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import scala.sys.env
+
 name := "story-packages"
 
 version := "1.0.0"
@@ -53,6 +55,10 @@ resolvers ++= Seq(
     Resolver.file("Local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)
 )
 
+buildInfoPackage := "app"
+buildInfoOptions += BuildInfoOption.BuildTime
+buildInfoKeys += "gitCommitId" -> env.getOrElse("GITHUB_SHA", "Unknown")
+
 lazy val jacksonVersion = "2.13.4"
 lazy val jacksonDatabindVersion = "2.13.4.2"
 
@@ -93,4 +99,4 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin, BuildInfoPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,12 +3,13 @@ logLevel := Level.Warn
 
 resolvers ++= Seq(
   Classpaths.typesafeReleases,
-  Resolver.sonatypeRepo("releases"),
   Resolver.typesafeRepo("releases")
-)
+) ++ Resolver.sonatypeOssRepos("releases")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
## Why are you doing this?

[Prout](https://www.theguardian.com/info/developer-blog/2015/feb/03/prout-is-your-pull-request-out) tells you when your pull request is actually deployed - or warns you if it's overdue, and _should_ have been deployed by now. 

Other examples of configuring Prout:
 * https://github.com/guardian/mobile-apps-api/pull/2507
 * https://github.com/guardian/apple-news/pull/232


Interestingly, as the [deploy](https://riffraff.gutools.co.uk/deployment/view/cc524009-0b52-44be-a658-c648417f217c) of #184 _did_ 'succeed', Prout wouldn't have given an Overdue warning - but would at least have prompted a good moment to test the PROD server.

<img width="1510" alt="image" src="https://github.com/guardian/story-packages/assets/52038/c0c371b1-1d6a-40f7-aac6-ce24fe1f3a1e">
