### PR TITLE
Read git commit id for TeamCity builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.gu.riffraff.artifact.BuildInfo
+
 import scala.sys.env
 
 name := "story-packages"
@@ -56,7 +58,7 @@ resolvers ++= Seq(
 )
 
 buildInfoPackage := "app"
-buildInfoKeys += "gitCommitId" -> env.getOrElse("GITHUB_SHA", "Unknown")
+buildInfoKeys += "gitCommitId" -> BuildInfo(baseDirectory.value).revision
 
 lazy val jacksonVersion = "2.13.4"
 lazy val jacksonDatabindVersion = "2.13.4.2"


### PR DESCRIPTION
Following on from #187 ... although `story-packages` is eventually going to get onto a GitHub Action CI build, for now TeamCity is performing CI, so reading `GITHUB_SHA` won't work. Thankfully, there's already some [well-tested code](https://github.com/guardian/sbt-riffraff-artifact/blob/de3189974368d3b607a57360491ab38331e41a16/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala#L100-L139) for reading the git commit id from a TeamCity environment in the sbt-riffraff-artifact plugin. That plugin itself _is_ deprecated, but simultaneously still recommended for TeamCity builds where they still exist.
