### PR TITLE
Added `.tool-versions` file and Metals to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ importmap.json
 
 jspm-snyk-workaround/package-lock.json
 jspm-snyk-workaround/result
+
+# Metals
+.metals/
+metals.sbt
+.bloop/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-8.422.05.1


### PR DESCRIPTION
Adding `.tool-versions` makes it clear which Java version to use.

We want to ignore build files for the Metals extension.
