### PR TITLE
add logging for users without permission to access tool

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -10,6 +10,7 @@ import com.amazonaws.regions.{Region, RegionUtils}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.gu.permissions.PermissionsConfig
 import org.apache.commons.io.IOUtils
 import play.api.Mode
 import play.api.{Configuration => PlayConfiguration}
@@ -170,6 +171,12 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val env
   object latest {
     lazy val pageSize = 20
   }
+
+  val permissions = PermissionsConfig(
+    stage = environment.stage,
+    region = aws.region,
+    awsCredentials = aws.mandatoryCredentials,
+  )
 }
 
 object Properties extends AutomaticResourceManagement {

--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -173,7 +173,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val env
   }
 
   val permissions = PermissionsConfig(
-    stage = environment.stage,
+    stage = environment.stage.toUpperCase,
     region = aws.region,
     awsCredentials = aws.mandatoryCredentials,
   )

--- a/app/story_packages/auth/PanDomainAuthActions.scala
+++ b/app/story_packages/auth/PanDomainAuthActions.scala
@@ -13,7 +13,7 @@ trait PanDomainAuthActions extends AuthActions with Results with Logging {
 
   val permissions = PermissionsProvider(config.permissions)
 
-  val StoryPackagesAccess = PermissionDefinition("story-packages-access", "story-packages")
+  val StoryPackagesAccess = PermissionDefinition("story_packages_access", "story-packages")
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     if (!permissions.hasPermission(StoryPackagesAccess, authedUser.user.email)) {

--- a/app/story_packages/auth/PanDomainAuthActions.scala
+++ b/app/story_packages/auth/PanDomainAuthActions.scala
@@ -3,6 +3,7 @@ package story_packages.auth
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.PanDomain
+import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
 import play.api.mvc._
 import conf.ApplicationConfiguration
 import story_packages.services.Logging
@@ -10,7 +11,14 @@ import story_packages.services.Logging
 trait PanDomainAuthActions extends AuthActions with Results with Logging {
   def config: ApplicationConfiguration
 
+  val permissions = PermissionsProvider(config.permissions)
+
+  val StoryPackagesAccess = PermissionDefinition("story-packages-access", "story-packages")
+
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
+    if (!permissions.hasPermission(StoryPackagesAccess, authedUser.user.email)) {
+      Logger.warn(s"User ${authedUser.user.email} does not have ${StoryPackagesAccess.name} permission")
+    }
     PanDomain.guardianValidation(authedUser)
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,7 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "com.gu" %% "content-api-client-aws" % "0.7.5",
     "com.gu" %% "fapi-client-play30" % "12.0.0",
     "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+    "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "story-packages-model" % "2.2.0",
     "com.gu" %% "thrift-serializer" % "4.0.2",
     "org.json4s" %% "json4s-native" % json4sVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds access permission, and logging when a user accesses without that permission



## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
