### PR TITLE
Play 3.0 upgrade

### DIFF
--- a/app/conf/Configuration.scala
+++ b/app/conf/Configuration.scala
@@ -6,7 +6,7 @@ import com.amazonaws.AmazonClientException
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.{Region, RegionUtils}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
@@ -57,7 +57,7 @@ class ApplicationConfiguration(val playConfiguration: PlayConfiguration, val env
     lazy val bucket = getMandatoryString("aws.bucket")
 
     object endpoints {
-      private val _region = Region.getRegion(Regions.fromName(region))
+      private val _region = RegionUtils.getRegion(region)
       val monitoring: String = _region.getServiceEndpoint(AmazonCloudWatch.ENDPOINT_PREFIX)
       val dynamoDB: String = _region.getServiceEndpoint(AmazonDynamoDB.ENDPOINT_PREFIX)
       val s3: String = _region.getServiceEndpoint(AmazonS3.ENDPOINT_PREFIX)

--- a/app/controllers/FaciaContentApiProxy.scala
+++ b/app/controllers/FaciaContentApiProxy.scala
@@ -2,7 +2,7 @@ package controllers
 
 import java.net.{URI, URLEncoder}
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import story_packages.auth.PanDomainAuthActions
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider

--- a/app/story_packages/metrics/metrics.scala
+++ b/app/story_packages/metrics/metrics.scala
@@ -3,7 +3,7 @@ package story_packages.metrics
 import java.io.File
 import java.lang.management.{GarbageCollectorMXBean, ManagementFactory}
 import java.util.concurrent.atomic.AtomicLong
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.amazonaws.services.cloudwatch.model.{Dimension, StandardUnit}
 import play.api.Logger
 import story_packages.services.Logging

--- a/app/story_packages/switchboard/Switchboard.scala
+++ b/app/story_packages/switchboard/Switchboard.scala
@@ -1,6 +1,6 @@
 package story_packages.switchboard
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.amazonaws.auth.AWSCredentialsProvider
 import story_packages.services.Logging
 

--- a/app/story_packages/updates/Reindex.scala
+++ b/app/story_packages/updates/Reindex.scala
@@ -1,6 +1,6 @@
 package story_packages.updates
 
-import akka.actor.Scheduler
+import org.apache.pekko.actor.Scheduler
 import com.amazonaws.services.dynamodbv2.document.Item
 import story_packages.model.StoryPackage
 import org.joda.time.DateTime

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ Compile / doc / sources := Seq.empty
 
 Compile / packageDoc / publishArtifact := false
 
-val awsVersion = "1.11.999"
+val awsVersion = "1.12.770"
 val capiModelsVersion = "25.1.0"
 val json4sVersion = "4.0.7"
 
@@ -41,8 +41,7 @@ resolvers ++= Seq(
 buildInfoPackage := "app"
 buildInfoKeys += "gitCommitId" -> env.getOrElse("GITHUB_SHA", "Unknown")
 
-lazy val jacksonVersion = "2.13.4"
-lazy val jacksonDatabindVersion = "2.13.4.2"
+lazy val jacksonVersion = "2.17.2"
 
 // these Jackson dependencies are required to resolve issues in Play 2.8.x https://github.com/orgs/playframework/discussions/11222
 val jacksonOverrides = Seq(
@@ -51,7 +50,7 @@ val jacksonOverrides = Seq(
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
 )
 
 libraryDependencies ++= jacksonOverrides ++  Seq(
@@ -66,16 +65,16 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
     "com.gu" %% "content-api-models-scala" % capiModelsVersion,
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
-    "com.gu" %% "content-api-client-aws" % "0.7",
-    "com.gu" %% "fapi-client-play28" % "4.0.4",
-    "com.gu" %% "pan-domain-auth-play_2-8" % "4.0.0",
+    "com.gu" %% "content-api-client-aws" % "0.7.5",
+    "com.gu" %% "fapi-client-play30" % "12.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
     "com.gu" %% "story-packages-model" % "2.2.0",
     "com.gu" %% "thrift-serializer" % "4.0.2",
     "org.json4s" %% "json4s-native" % json4sVersion,
     "org.json4s" %% "json4s-jackson" % json4sVersion,
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
-    "com.typesafe.play" %% "play-json" % "2.9.4",
-    "org.julienrf" %% "play-json-derived-codecs" % "10.1.0",
+    "com.typesafe.play" %% "play-json" % "2.10.5",
+    "org.julienrf" %% "play-json-derived-codecs" % "11.0.0",
     "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ Compile / doc / sources := Seq.empty
 Compile / packageDoc / publishArtifact := false
 
 val awsVersion = "1.11.999"
-val capiModelsVersion = "17.4.0"
-val json4sVersion = "4.0.3"
+val capiModelsVersion = "25.1.0"
+val json4sVersion = "4.0.7"
 
 resolvers ++= Seq(
     Resolver.file("Local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns)

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "org.json4s" %% "json4s-native" % json4sVersion,
     "org.json4s" %% "json4s-jackson" % json4sVersion,
     "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
-    "com.typesafe.play" %% "play-json" % "2.10.5",
+    "org.playframework" %% "play-json" % "3.0.4",
     "org.julienrf" %% "play-json-derived-codecs" % "11.0.0",
     "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,5 @@
-akka {
-  akka.loggers = ["akka.event.Logging$DefaultLogger", "akka.event.slf4j.Slf4jLogger"]
+pekko {
+  loggers = ["org.apache.pekko.event.Logging$DefaultLogger", "org.apache.pekko.event.slf4j.Slf4jLogger"]
   loglevel = WARNING
   actor {
     default-dispatcher = {
@@ -34,12 +34,6 @@ play {
     loader: Loader
   }
 
-  crypto {
-    # The secret key is used to secure cryptographics functions.
-    # If you deploy your application to several instances be sure to use the same key!
-    secret: "test"
-  }
-
   il8n {
     langs: "en"
   }
@@ -49,6 +43,10 @@ play {
   }
 
   http {
+    secret {
+        # If a Play app needs a secure Play Application Secret, it should use https://github.com/guardian/play-secret-rotation
+        key="This app doesn't need a secure PAS so long as it DOES NOT use session cookies, CSRF tokens, etc"
+    }
     session {
       secure=true
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.10.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers ++= Seq(
   Resolver.typesafeRepo("releases")
 ) ++ Resolver.sonatypeOssRepos("releases")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 


### PR DESCRIPTION
## What does this change?

Minimal changes to get to Play 3.0

Requires FAPI and pan-domain-auth-play upgrades to versions with support for Play.

This then required content-api-client-aws and capi-models to be upgraded to align versions of common dependencies.

There still seems to be a Jackson incompatibility between Play and Pekko.