### PR TITLE
Update Snyk CI to use java 11

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,7 +13,7 @@ jobs:
       DEBUG: true
       ORG: guardian
       SKIP_NODE: true
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
       EXCLUDE: package.json,package-lock.json # since we use the jspm workaround below
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

Snyk CI is failing after https://github.com/guardian/story-packages/pull/200 merged. Hopefully this should resolve.