### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/app/controllers/StoryPackagesBaseController.scala
+++ b/app/controllers/StoryPackagesBaseController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, S3BucketLoader}
 import conf.ApplicationConfiguration
 import play.api.libs.ws.WSClient
 import play.api.mvc.{BaseController, ControllerComponents}
@@ -14,11 +14,12 @@ abstract class StoryPackagesBaseController(
   final override val controllerComponents: ControllerComponents = components
 
   lazy val panDomainSettings: PanDomainAuthSettingsRefresher =
-    new PanDomainAuthSettingsRefresher(
-      config.pandomain.domain,
-      config.pandomain.service,
-      config.pandomain.bucketName,
-      config.pandomain.settingsFileKey,
-      config.aws.s3Client.get
+    PanDomainAuthSettingsRefresher(
+      domain = config.pandomain.domain,
+      system = config.pandomain.service,
+      S3BucketLoader.forAwsSdkV1(
+      config.aws.s3Client.get,
+        "pan-domain-auth-settings"
+      )
     )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "0.7.5",
     "com.gu" %% "fapi-client-play30" % "12.0.0",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "story-packages-model" % "2.2.0",
     "com.gu" %% "thrift-serializer" % "4.0.2",


### PR DESCRIPTION
This upgrades Panda from v4 to v7, allowing us to use [key rotation](https://github.com/guardian/pan-domain-authentication/pull/150).

Follows the guidance from https://github.com/guardian/pan-domain-authentication/issues/160 and based on https://github.com/guardian/atom-workshop/pull/361

## Testing
