### PR TITLE
require users to have been granted the access permission to access the tool

### DIFF
--- a/app/story_packages/auth/PanDomainAuthActions.scala
+++ b/app/story_packages/auth/PanDomainAuthActions.scala
@@ -36,7 +36,7 @@ trait PanDomainAuthActions extends AuthActions with Results with Logging {
       s"${claimedAuth.user.email} is not valid for use with the Story Packages tool as you need to have two factor authentication enabled." +
        s" Please contact the Helpdesk by emailing 34444@theguardian.com or calling 34444 and request assistance setting up two factor authentication on your Google account."
     } else if (claimedAuth.user.emailDomain != "guardian.co.uk") {
-      s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
+      s"${claimedAuth.user.email} is not valid for use with the Story Packages Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
     } else {
       s"${claimedAuth.user.email} has not been granted access to the Story Packages tool. Please contact Central Production at central.production@guardian.co.uk requesting access to the Story Packages tool."
     }

--- a/app/story_packages/auth/PanDomainAuthActions.scala
+++ b/app/story_packages/auth/PanDomainAuthActions.scala
@@ -18,8 +18,10 @@ trait PanDomainAuthActions extends AuthActions with Results with Logging {
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     if (!permissions.hasPermission(StoryPackagesAccess, authedUser.user.email)) {
       Logger.warn(s"User ${authedUser.user.email} does not have ${StoryPackagesAccess.name} permission")
+      false
+    } else {
+      PanDomain.guardianValidation(authedUser)
     }
-    PanDomain.guardianValidation(authedUser)
   }
 
   override def authCallbackUrl: String = config.pandomain.host  + "/oauthCallback"

--- a/app/story_packages/auth/PanDomainAuthActions.scala
+++ b/app/story_packages/auth/PanDomainAuthActions.scala
@@ -33,10 +33,12 @@ trait PanDomainAuthActions extends AuthActions with Results with Logging {
 
   override def invalidUserMessage(claimedAuth: AuthenticatedUser): String = {
     if( (claimedAuth.user.emailDomain == "guardian.co.uk") && !claimedAuth.multiFactor) {
-      s"${claimedAuth.user.email} is not valid for use with the Fronts Tool as you need to have two factor authentication enabled." +
-       s" Please contact the Helpdesk by emailing 34444@theguardian.com or calling 34444 and request access to Composer CMS tools."
-    } else {
+      s"${claimedAuth.user.email} is not valid for use with the Story Packages tool as you need to have two factor authentication enabled." +
+       s" Please contact the Helpdesk by emailing 34444@theguardian.com or calling 34444 and request assistance setting up two factor authentication on your Google account."
+    } else if (claimedAuth.user.emailDomain != "guardian.co.uk") {
       s"${claimedAuth.user.email} is not valid for use with the Fronts Tool. You need to use your Guardian Google account to login. Please sign in with your Guardian Google account first, then retry logging in."
+    } else {
+      s"${claimedAuth.user.email} has not been granted access to the Story Packages tool. Please contact Central Production at central.production@guardian.co.uk requesting access to the Story Packages tool."
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Users should have been granted the access permission, in order to have permission to access the tool. Followup to #198 to enforce the permission.

## How to test

Deploy to CODE, and try accessing the tool both with and without the correct permission. Are you prevented from accessing without the permission -- with a useful message for seeking assistance -- and allowed to access with the permission?
