### PR TITLE
Enable ASG migration in progress option

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,6 +4,7 @@ deployments:
   story-packages:
     type: autoscaling
     parameters:
+      asgMigrationInProgress: true
       bucketSsmLookup: true
       bucketSsmKey: /account/services/artifact.bucket.story-packages
     dependencies: [packages-ami]


### PR DESCRIPTION
## What does this change?

Enables a riff-raff option to deploy the app to multiple ASGs.  We are currently migration from one VPC to another so expect there to be 2 ASGs.
