### PR TITLE
Adds pixel tracking to improve usage insights

### DIFF
--- a/app/views/templates/header.scala.html
+++ b/app/views/templates/header.scala.html
@@ -51,4 +51,16 @@
     <div style="display: none;" class="header__group state__pending" data-bind="visible: pending">
         <div class="updating">Updating</div>
     </div>
+
+    <script>
+        const image = new Image();
+        @if(stage == "PROD"){
+            const telemetryURL = "https://user-telemetry.gutools.co.uk";
+        } else if (stage == "CODE"){
+            const telemetryURL = "https://user-telemetry.code.dev-gutools.co.uk";
+        } else {
+            const telemetryURL = "https://user-telemetry.local.dev-gutools.co.uk";
+        }
+        image.src = `${telemetryURL}/guardian-tool-accessed?app=ten-four_quiz-builder&path=${window.location.pathname}`;
+    </script>
 </header>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Addressing https://github.com/guardian/flexible-content/issues/5532, this PR adds the telemetry client tracking pixel into Twirl header component. This should give us insights into how often the tool is being used and by how many people.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This can be run locally looking at observing network traffic (note: the local environment is passed a `CODE` stage value).
Ideally we should deploy this to CODE to confirm it is working as expected.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Usage information available in the the [tool audit dashboard](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=packages.gutools.co.uk&var-path=All&var-interval=1d&var-chosen_apps=All&var-chosen_stacks=All&var-owners=Fronts+and+Curation&from=1746947998078&to=1749539998078)
