### PR TITLE
remove asg migration flag to stop riff-raff from deploying to old infra

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,7 +4,6 @@ deployments:
   story-packages:
     type: autoscaling
     parameters:
-      asgMigrationInProgress: true
       bucketSsmLookup: true
       bucketSsmKey: /account/services/artifact.bucket.story-packages
     dependencies: [packages-ami]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Riff-raff has been configured to deploy both old and new autoscaling groups during VPC migration.  In order to be able to delete the old infra in https://github.com/guardian/editorial-tools-platform/pull/940, we need to stop the parallel deployment and only deploy to the new infra.

We discovered this requirement because https://github.com/guardian/editorial-tools-platform/pull/949 was deployed to Editorial Tools::Fronts::Cloudformation CODE and subsequent deployments of facia-tool failed.


## How to test
To check in CODE, I will re-apply https://github.com/guardian/editorial-tools-platform/pull/940 to CODE, then deploy this change.  We should see the story-packages deployment succeed.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
