### PR TITLE
Use correct table for reindex

### DIFF
--- a/app/story_packages/services/DynamoReindexJobs.scala
+++ b/app/story_packages/services/DynamoReindexJobs.scala
@@ -25,7 +25,7 @@ class DynamoReindexJobs(config: ApplicationConfiguration) extends Logging {
     .dynamoDbClient(client)
     .build();
 
-  private lazy val table = enhancedClient.table(config.storage.configTable,
+  private lazy val table = enhancedClient.table(config.reindex.progressTable,
     TableSchema.documentSchemaBuilder()
       .addIndexPartitionKey(TableMetadata.primaryIndexName(), "reindexStatus", AttributeValueType.S)
       .addIndexSortKey(TableMetadata.primaryIndexName(), "startTime", AttributeValueType.S)


### PR DESCRIPTION
## What does this change?

Tiny change to use the correct table for tracking reindexes. This resolves a bug introduced as part of [AWS SDKv2 upgrade](https://github.com/guardian/story-packages/pull/212)


## How has this change been tested?

Running a reindex in CODE, we see the expected data in CAPI. We saw 65 instances of "Ignore reindex of empty story package" in the logs, there are 4 packages marked as `isHidden` in dynamodb and 29 packages land in CAPI. This adds up to the 98 packages that were in dynamodb.