### PR TITLE
Bump CAPI Models to "38.0.0" and FAPI to "30.0.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ Compile / packageDoc / publishArtifact := false
 
 val awsVersion = "1.12.770"
 val awsV2Version = "2.40.14"
-val capiModelsVersion = "34.0.0"
+val capiModelsVersion = "38.0.0"
 val json4sVersion = "4.0.7"
 
 resolvers ++= Seq(
@@ -66,7 +66,7 @@ libraryDependencies ++= jacksonOverrides ++  Seq(
     "com.gu" %% "content-api-models-json" % capiModelsVersion,
     "com.gu" %% "content-api-client-aws" % "1.0.1",
     "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "7.0.0",
-    "com.gu" %% "fapi-client-play30" % "28.0.0",
+    "com.gu" %% "fapi-client-play30" % "30.0.0",
     "com.gu" %% "pan-domain-auth-play_3-0" % "13.0.0",
     "com.gu" %% "editorial-permissions-client" % "6.0.2",
     "com.gu" %% "story-packages-model" % "2.2.0",


### PR DESCRIPTION

## What does this change?
Bump CAPI to "38.0.0" and FAPI to "30.0.0" to keep the code base up to date.

## How has this change been tested?
Deployed this branch to `CODE` and checked that the application build and runs successfully.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
